### PR TITLE
Remove abi.decode from event payload parsing

### DIFF
--- a/apps/strongbox/src/android/call_core.rs
+++ b/apps/strongbox/src/android/call_core.rs
@@ -44,7 +44,7 @@ fn call_core_inner(
 
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn Java_com_ptokenssentinelandroidapp_RustBridge_callCore(
+pub extern "C" fn Java_proofcastlabs_tee_MainActivity_callCore(
     env: JNIEnv,
     _class: JClass,
     strongbox_java_class: JObject,

--- a/apps/strongbox/src/android/mod.rs
+++ b/apps/strongbox/src/android/mod.rs
@@ -11,8 +11,8 @@ mod strongbox;
 mod type_aliases;
 
 pub use self::{
-    call_core::Java_com_ptokenssentinelandroidapp_RustBridge_callCore,
-    rust_java_log::Java_com_ptokenssentinelandroidapp_rustlogger_RustLogger_log,
+    call_core::Java_proofcastlabs_tee_MainActivity_callCore,
+    rust_java_log::Java_proofcastlabs_tee_logging_RustLogger_log,
 };
 use self::{
     constants::CORE_TYPE,

--- a/apps/strongbox/src/android/rust_java_log.rs
+++ b/apps/strongbox/src/android/rust_java_log.rs
@@ -25,7 +25,7 @@ fn parse_java_log<'a>(env: &'a JNIEnv<'a>, log_level: JString, log_msg: JString)
 
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn Java_com_ptokenssentinelandroidapp_rustlogger_RustLogger_log(
+pub extern "C" fn Java_proofcastlabs_tee_logging_RustLogger_log(
     env: JNIEnv,
     _class: JClass,
     log_level: JString,

--- a/apps/strongbox/src/lib.rs
+++ b/apps/strongbox/src/lib.rs
@@ -9,6 +9,6 @@ extern crate common;
 mod android;
 
 pub use self::android::{
-    Java_com_ptokenssentinelandroidapp_RustBridge_callCore,
-    Java_com_ptokenssentinelandroidapp_rustlogger_RustLogger_log,
+    Java_proofcastlabs_tee_MainActivity_callCore,
+    Java_proofcastlabs_tee_logging_RustLogger_log,
 };

--- a/common/sentinel/src/signed_events/signed_event.rs
+++ b/common/sentinel/src/signed_events/signed_event.rs
@@ -4,7 +4,6 @@ use common_eth::{EthLog, EthPrivateKey, EthSigningCapabilities};
 use common_metadata::MetadataChainId;
 use common_network_ids::ProtocolId;
 use derive_getters::Getters;
-use ethabi::{decode as eth_abi_decode, ParamType as EthAbiParamType, Token as EthAbiToken};
 use ethereum_types::H256 as EthHash;
 use serde::{Deserialize, Serialize};
 
@@ -71,16 +70,8 @@ impl SignedEvent {
             .map(|t| t.as_bytes().to_vec())
             .collect::<Vec<_>>()
             .concat();
-        let event_bytes = eth_abi_decode(&[EthAbiParamType::Tuple(vec![EthAbiParamType::Bytes])], &self.log.data)?;
-        let event_bytes = match &event_bytes[0] {
-            EthAbiToken::Tuple(value) => match &value[0] {
-                EthAbiToken::Bytes(bytes) => Ok(bytes.to_vec()),
-                _ => Err(SignedEventError::LogDataError("bad log data format".to_string())),
-            },
-            _ => Err(SignedEventError::LogDataError("bad log data format".to_string())),
-        }?;
-
-        Ok([address, sha256_hash_bytes(&topics), event_bytes].concat())
+        
+        Ok([address, sha256_hash_bytes(&topics), self.log.data.to_vec()].concat())
     }
 
     fn calculate_event_id(&self) -> Result<EventId, EventIdError> {
@@ -134,7 +125,7 @@ mod tests {
         let merkle_proof = MerkleProof::new(vec![vec![]]);
         let result = SignedEvent::new(metadata_chain_id, log, tx_id_hash, block_id_hash, &pk, merkle_proof).unwrap();
 
-        let expected_signature = "5f39735498e1b86e914aa1e297dc2fe33a828b68d3720884953a52bdb43d5ed03b08465279ca638cf671cb037b55eac9033b5f20c9cb7eeffc8475fa8ef35f291c".to_string();
+        let expected_signature = "d1820d529a376ed15395faa94a0d8d535620ebc63755a9e57c9cc6d25ac503fa6a14ffa06bc9257ddd3b335da620333fddec0ddf17b151154c3eaa6fe880ff481c".to_string();
 
         assert_eq!(result.signature.unwrap(), expected_signature);
     }


### PR DESCRIPTION
 - Can't use abi.decode off chain since it expects an application specific format
 - We have to be compatible with ANY EVM event
 - Also changed the package name for the java wirings to `proofcastlabs`
 