### PR TITLE
Revert signed event encoding

### DIFF
--- a/apps/strongbox/src/android/call_core.rs
+++ b/apps/strongbox/src/android/call_core.rs
@@ -44,7 +44,7 @@ fn call_core_inner(
 
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn Java_com_ptokenssentinelandroidapp_RustBridge_callCore(
+pub extern "C" fn Java_proofcastlabs_tee_MainActivity_callCore(
     env: JNIEnv,
     _class: JClass,
     strongbox_java_class: JObject,

--- a/apps/strongbox/src/android/mod.rs
+++ b/apps/strongbox/src/android/mod.rs
@@ -11,8 +11,8 @@ mod strongbox;
 mod type_aliases;
 
 pub use self::{
-    call_core::Java_com_ptokenssentinelandroidapp_RustBridge_callCore,
-    rust_java_log::Java_com_ptokenssentinelandroidapp_rustlogger_RustLogger_log,
+    call_core::Java_proofcastlabs_tee_MainActivity_callCore,
+    rust_java_log::Java_proofcastlabs_tee_logging_RustLogger_log,
 };
 use self::{
     constants::CORE_TYPE,

--- a/apps/strongbox/src/android/rust_java_log.rs
+++ b/apps/strongbox/src/android/rust_java_log.rs
@@ -25,7 +25,7 @@ fn parse_java_log<'a>(env: &'a JNIEnv<'a>, log_level: JString, log_msg: JString)
 
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn Java_com_ptokenssentinelandroidapp_rustlogger_RustLogger_log(
+pub extern "C" fn Java_proofcastlabs_tee_logging_RustLogger_log(
     env: JNIEnv,
     _class: JClass,
     log_level: JString,

--- a/apps/strongbox/src/lib.rs
+++ b/apps/strongbox/src/lib.rs
@@ -8,7 +8,4 @@ extern crate common;
 
 mod android;
 
-pub use self::android::{
-    Java_com_ptokenssentinelandroidapp_RustBridge_callCore,
-    Java_com_ptokenssentinelandroidapp_rustlogger_RustLogger_log,
-};
+pub use self::android::{Java_proofcastlabs_tee_MainActivity_callCore, Java_proofcastlabs_tee_logging_RustLogger_log};


### PR DESCRIPTION
 - Can't use abi.decode off chain since it expects an application specific format
 - We have to be compatible with ANY EVM event
 - Also changed the package name for the java wirings to `proofcastlabs`
 